### PR TITLE
Update for multiple Chart dependencies

### DIFF
--- a/HelmUpgradeBot.py
+++ b/HelmUpgradeBot.py
@@ -164,7 +164,8 @@ class HelmUpgradeBot(object):
         chart_urls = {
             self.deployment: f"https://raw.githubusercontent.com/{self.repo_owner}/{self.repo_name}/master/{self.chart_name}/requirements.yaml",
             "binderhub": "https://raw.githubusercontent.com/jupyterhub/helm-chart/gh-pages/index.yaml",
-            "nginx-ingress": "https://raw.githubusercontent.com/helm/charts/master/stable/nginx-ingress/Chart.yaml"
+            "nginx-ingress": "https://raw.githubusercontent.com/helm/charts/master/stable/nginx-ingress/Chart.yaml",
+            "cert-manager": None  # URL for this chart is hard-coded into get_cert_manager_version function
         }
 
         for chart in chart_urls.keys():

--- a/HelmUpgradeBot.py
+++ b/HelmUpgradeBot.py
@@ -407,7 +407,7 @@ class HelmUpgradeBot(object):
 
         today = pd.Timestamp.now().tz_localize(None)
         body = "\n".join([
-            "This PR is updating the local Helm Chart to the most recent BinderHub Helm Chart version."
+            "This PR is updating the local Helm Chart to the most recent Chart dependency versions."
         ])
 
         logging.info("Pull Request body written")

--- a/HelmUpgradeBot.py
+++ b/HelmUpgradeBot.py
@@ -151,7 +151,7 @@ class HelmUpgradeBot(object):
     ):
 
         res = requests.get(url)
-        soup = BeautifulSoup(res, "html.parser")
+        soup = BeautifulSoup(res.content, "html.parser")
 
         links = soup.find_all("a", attrs={"title": True})
 
@@ -240,7 +240,8 @@ class HelmUpgradeBot(object):
             logging.info(f"HelmUpgradeBot does not have a fork of: {self.repo_name}")
 
     def check_versions(self):
-        charts = ["binderhub", "nginx-ingress"]
+        charts = list(self.chart_info.keys())
+        charts.remove(self.deployment)
 
         if self.dry_run:
             logging.info("THIS IS A DRY-RUN. THE HELM CHART WILL NOT BE UPGRADED.")

--- a/HelmUpgradeBot.py
+++ b/HelmUpgradeBot.py
@@ -7,8 +7,10 @@ import logging
 import requests
 import argparse
 import datetime
+import numpy as np
 import pandas as pd
 from CustomExceptions import *
+from itertools import compress
 from run_command import run_cmd
 from yaml import safe_load as load
 from yaml import safe_dump as dump
@@ -229,13 +231,12 @@ class HelmUpgradeBot(object):
         condition = [(self.chart_info[chart]["version"] !=
             self.chart_info[self.deployment][chart]["version"])
             for chart in charts]
-        print(condition)
 
-        # if version_cond:
-        #     logging.info("Helm upgrade required")
-        #     self.upgrade_chart()
-        # else:
-        #     logging.info(f"{self.deployment} is up-to-date with current BinderHub Helm Chart release!")
+        if np.any(condition):
+            logging.info(f"Helm upgrade required for the following charts: {list(compress(charts, condition))}")
+            # self.upgrade_chart()
+        else:
+            logging.info(f"{self.deployment} is up-to-date with current BinderHub Helm Chart release!")
 
     def upgrade_chart(self):
         # Forking repo

--- a/HelmUpgradeBot.py
+++ b/HelmUpgradeBot.py
@@ -18,9 +18,7 @@ from yaml import safe_dump as dump
 # Setup log config
 logging.basicConfig(
     level=logging.DEBUG,
-    filename="HelmUpgradeBot_{}.log".format(
-        datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-    ),
+    filename="HelmUpgradeBot.log",
     filemode="a",
     format="[%(asctime)s %(levelname)s] %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S"

--- a/HelmUpgradeBot.py
+++ b/HelmUpgradeBot.py
@@ -149,8 +149,7 @@ class HelmUpgradeBot(object):
         chart_urls = {
             self.deployment: f"https://raw.githubusercontent.com/{self.repo_owner}/{self.repo_name}/master/{self.chart_name}/requirements.yaml",
             "binderhub": "https://raw.githubusercontent.com/jupyterhub/helm-chart/gh-pages/index.yaml",
-            "nginx-ingress": "https://raw.githubusercontent.com/helm/charts/master/stable/nginx-ingress/Chart.yaml",
-            "cert-manager": "https://raw.githubusercontent.com/helm/charts/master/stable/cert-manager/Chart.yaml"
+            "nginx-ingress": "https://raw.githubusercontent.com/helm/charts/master/stable/nginx-ingress/Chart.yaml"
         }
 
         for chart in chart_urls.keys():
@@ -221,17 +220,22 @@ class HelmUpgradeBot(object):
             logging.info(f"HelmUpgradeBot does not have a fork of: {self.repo_name}")
 
     def check_versions(self):
+        charts = ["binderhub", "nginx-ingress"]
+
         if self.dry_run:
             logging.info("THIS IS A DRY-RUN. THE HELM CHART WILL NOT BE UPGRADED.")
 
         # Create conditions
-        version_cond = (self.chart_info["binderhub"]["version"] != self.chart_info[self.deployment]["binderhub"]["version"])
+        condition = [(self.chart_info[chart]["version"] !=
+            self.chart_info[self.deployment][chart]["version"])
+            for chart in charts]
+        print(condition)
 
-        if version_cond:
-            logging.info("Helm upgrade required")
-            self.upgrade_chart()
-        else:
-            logging.info(f"{self.deployment} is up-to-date with current BinderHub Helm Chart release!")
+        # if version_cond:
+        #     logging.info("Helm upgrade required")
+        #     self.upgrade_chart()
+        # else:
+        #     logging.info(f"{self.deployment} is up-to-date with current BinderHub Helm Chart release!")
 
     def upgrade_chart(self):
         # Forking repo

--- a/HelmUpgradeBot.py
+++ b/HelmUpgradeBot.py
@@ -191,6 +191,7 @@ class HelmUpgradeBot(object):
                 self.chart_info["binderhub"]["version"] = updates_sorted[-1]["version"]
 
             elif chart == "cert-manager":
+                # cert-manager chart
                 self.chart_info["cert-manager"] = {}
                 self.chart_info["cert-manager"]["version"] = self.get_cert_manager_version()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 pyyaml
 requests
+beautifulsoup4


### PR DESCRIPTION
This PR allows HelmUpgradeBot to also update chart dependencies for `nginx-ingress` and `cert-manager`.

fix #15 