### PR TITLE
Workaround: Branch deletion

### DIFF
--- a/helm_bot/app.py
+++ b/helm_bot/app.py
@@ -3,7 +3,7 @@ import yaml
 import shutil
 import logging
 
-from itertools import compress
+from itertools import compress, product
 
 from .azure import get_token
 
@@ -153,10 +153,9 @@ def update_local_file(
     with open(filename, "r") as stream:
         chart_yaml = yaml.safe_load(stream)
 
-    for chart in charts_to_update:
-        for dep in chart_yaml["dependencies"]:
-            if dep["name"] == chart:
-                dep["version"] = chart_info[chart]
+    for chart, dep in product(charts_to_update, chart_yaml["dependencies"]):
+        if dep["name"] == chart:
+            dep["version"] = chart_info[chart]
 
     with open(filename, "w") as stream:
         yaml.safe_dump(chart_yaml, stream)

--- a/helm_bot/app.py
+++ b/helm_bot/app.py
@@ -1,5 +1,7 @@
 import os
 import yaml
+import string
+import random
 import shutil
 import logging
 
@@ -247,7 +249,13 @@ def run(
 
     if (len(charts_to_update) > 0) and (not dry_run):
         # Check if Pull Request exists
-        pr_exists = find_existing_pr(repo_api, target_branch, token)
+        pr_exists, branch_name = find_existing_pr(repo_api, token)
+
+        if branch_name is None:
+            random_id = "".join(random.sample(string.ascii_letters, 4))
+            target_branch = target_branch + "-" + random_id
+        else:
+            target_branch = branch_name
 
         # Check if a fork exists
         fork_exists = check_fork_exists(repo_name, token)

--- a/helm_bot/github.py
+++ b/helm_bot/github.py
@@ -173,7 +173,7 @@ def checkout_branch(
     fork_exists = check_fork_exists(repo_name, token)
 
     if fork_exists and not pr_exists:
-        delete_old_branch(repo_name, target_branch, token)
+        # delete_old_branch(repo_name, target_branch, token) <-- DEPRECATED
 
         logger.info("Pulling main branch of: %s/%s" % (repo_owner, repo_name))
         pull_cmd = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 coverage
+jmespath
 pytest
 pyyaml
 requests

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ URL = "https://github.com/HelmUpgradeBot/hub23-deploy-upgrades"
 VERSION = None
 
 # What packages are required for this module to be executed?
-REQUIRED = ["pyyaml", "requests"]
+REQUIRED = ["jmespath", "pyyaml", "requests"]
 
 # What packages are optional?
 EXTRAS = {}

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -277,20 +277,18 @@ def test_checkout_branch_exists(capture):
     mock_check_fork = patch(
         "helm_bot.github.check_fork_exists", return_value=True
     )
-    mock_delete_branch = patch("helm_bot.github.delete_old_branch")
+    # mock_delete_branch = patch("helm_bot.github.delete_old_branch") <-- DEPRECATED
     mock_run_cmd = patch(
         "helm_bot.github.run_cmd", return_value={"returncode": 0}
     )
 
-    with mock_check_fork as mock1, mock_delete_branch as mock2, mock_run_cmd as mock3:
+    with mock_check_fork as mock1, mock_run_cmd as mock2:
         checkout_branch(repo_owner, repo_name, target_branch, token, pr_exists)
 
         assert mock1.call_count == 1
-        assert mock2.call_count == 1
-        assert mock3.call_count == 2
+        assert mock2.call_count == 2
         mock1.assert_called_with(repo_name, token)
-        mock2.assert_called_with(repo_name, target_branch, token)
-        assert mock3.call_args_list == expected_calls
+        assert mock2.call_args_list == expected_calls
 
         capture.check_present()
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request!

Don't worry, these HTML comments won't render in your issue.
Feel free to delete them once you've read them :) -->

### Summary
<!-- Please describe the purpose of this PR.
Is it fixing a bug or adding a feature?

Please reference relevant issue numbers with action words to close them if relevant. -->

The bot has not been running for a while. Upon local testing, it was found that it did not have permission to delete remote branches. This PR is deprecating the use of the `delete_old_branch` function. Instead, the bot will find the most recent open PR and push new commits to that branch, or append 4 random characters to the end of the provided target branch name so as not to clash with previous branches.

### What's changed?
<!-- You can use this section to go into more detail about what's changed.
We recommend using bullet points. -->

- `github.py`
  - `delete_old_branch` deprecated
  - `find_existing_prs` updated 
- `app.py`
  - appends random chars to `target_branch`
- `test_github.py`
  - exclude `delete_old_branch` from tests

### What should a reviewer concentrate their feedback on?
<!-- You can use this section to request specific feedback.
We recommend using check boxes. -->

- [x] Everything looks ok?
