### PR TITLE
Disable schedule trigger to run the bot in GitHub Actions

### DIFF
--- a/.github/workflows/run-bot.yml
+++ b/.github/workflows/run-bot.yml
@@ -7,8 +7,8 @@ on:
         description: 'Perform a dry-run. Takes "true" or "false".'
         required: false
         default: 'false'
-  schedule:
-    - cron: "0 10 * * *"
+#   schedule:
+#     - cron: "0 10 * * *"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request!

Don't worry, these HTML comments won't render in your issue.
Feel free to delete them once you've read them :) -->

### Summary
<!-- Please describe the purpose of this PR.
Is it fixing a bug or adding a feature?

Please reference relevant issue numbers with action words to close them if relevant. -->

The bot is not presently functioning correctly and may need some reconfiguration. This PR removes the `schedule` rtigger from the `run-bot` CI job to prevent the bot from running every day at 10am (manual runs and PR runs can still be triggered).

### What's changed?
<!-- You can use this section to go into more detail about what's changed.
We recommend using bullet points. -->

- `.github/workflows/run-bot.yml`

### What should a reviewer concetrate their feedback on?
<!-- You can use this section to request specific feedback.
We recommend using check boxes. -->

- [x] Everything looks ok?
