### PR TITLE
Disable badge update workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,40 +86,40 @@ jobs:
           name: htmlcov
           path: htmlcov/
 
-  update-badge:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: run-tests
-    runs-on: ubuntu-latest
+  # update-badge:
+  #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  #   needs: run-tests
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v2
 
-      - name: Download htmlcov artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: htmlcov
-          path: htmlcov
+  #     - name: Download htmlcov artifact
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: htmlcov
+  #         path: htmlcov
 
-      - name: Setup Python 3.8
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
+  #     - name: Setup Python 3.8
+  #       uses: actions/setup-python@v1
+  #       with:
+  #         python-version: 3.8
 
-      - name: Install dependencies
-        run:
-          python -m pip install -U pip bs4
+  #     - name: Install dependencies
+  #       run:
+  #         python -m pip install -U pip bs4
 
-      - name: Run script to update badge metadata
-        run: |
-          python update_coverage_badge.py
+  #     - name: Run script to update badge metadata
+  #       run: |
+  #         python update_coverage_badge.py
 
-      - name: Add and commit the edited metadata file
-        uses: EndBug/add-and-commit@v4
-        with:
-          add: 'badge_metadata.json'
-          author_name: CI User
-          author_email: ci-user@github.local
-          message: 'Update coverage badge metadata'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Add and commit the edited metadata file
+  #       uses: EndBug/add-and-commit@v4
+  #       with:
+  #         add: 'badge_metadata.json'
+  #         author_name: CI User
+  #         author_email: ci-user@github.local
+  #         message: 'Update coverage badge metadata'
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/badge_metadata.json
+++ b/badge_metadata.json
@@ -1,6 +1,6 @@
 {
     "color": "orange",
     "label": "coverage.py",
-    "message": "74%",
+    "message": "68%",
     "schemaVersion": 1
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request!

Don't worry, these HTML comments won't render in your issue.
Feel free to delete them once you've read them :) -->

### Summary
<!-- Please describe the purpose of this PR.
Is it fixing a bug or adding a feature?

Please reference relevant issue numbers with action words to close them if relevant. -->

Our workflow to update the `badge_metadata.json` file actually fails since pushing to a protected branch is not permitted (though it still reports as passing?). This PR disables that job and manually updates the badge metadata. We should fix this in the future though.

### What's changed?
<!-- You can use this section to go into more detail about what's changed.
We recommend using bullet points. -->

- `.github/workflows/ci.yml`

### What should a reviewer concentrate their feedback on?
<!-- You can use this section to request specific feedback.
We recommend using check boxes. -->

- [ ] Everything looks ok?
