### PR TITLE
Add functionality to assign reviewers to Pull Request

### DIFF
--- a/badge_metadata.json
+++ b/badge_metadata.json
@@ -1,6 +1,6 @@
 {
     "color": "orange",
     "label": "coverage.py",
-    "message": "68%",
+    "message": "69%",
     "schemaVersion": 1
 }

--- a/helm_bot/__init__.py
+++ b/helm_bot/__init__.py
@@ -7,6 +7,7 @@ from .cli import parse_args, check_parser
 from .github import (
     add_commit_push,
     add_labels,
+    assign_reviewers,
     check_fork_exists,
     delete_old_branch,
     checkout_branch,

--- a/helm_bot/app.py
+++ b/helm_bot/app.py
@@ -181,6 +181,7 @@ def upgrade_chart(
     target_branch: str,
     token: str,
     labels: list,
+    reviewers: list,
     pr_exists: bool,
 ) -> None:
     """Upgrade the dependencies in the helm chart
@@ -210,7 +211,7 @@ def upgrade_chart(
     add_commit_push(
         filename, charts_to_update, chart_info, repo_name, target_branch, token
     )
-    create_pr(repo_api, base_branch, target_branch, token, labels)
+    create_pr(repo_api, base_branch, target_branch, token, labels, reviewers)
 
 
 def run(
@@ -220,6 +221,7 @@ def run(
     base_branch: str,
     target_branch: str,
     labels: list,
+    reviewers: list,
     token: str,
     dry_run: bool = False,
 ) -> None:
@@ -232,6 +234,7 @@ def run(
         base_branch (str): The base branch for Pull Requests
         target_branch (str): The target branch for Pull Requests
         labels (list): A list of labels to add to the Pull Request
+        reviewers (list):
         token (str): A GitHub API token
         dry_run (bool, optional): Don't open a Pull Request. Defaults to False.
     """
@@ -274,6 +277,7 @@ def run(
             target_branch,
             token,
             labels,
+            reviewers,
             pr_exists,
         )
 

--- a/helm_bot/cli.py
+++ b/helm_bot/cli.py
@@ -59,6 +59,13 @@ def parse_args(args):
         default=None,
         help="List of labels to assign to the Pull Request",
     )
+    parser.add_argument(
+        "-r",
+        "--reviewers",
+        nargs="+",
+        default=None,
+        help="List of GitHub handles to request reviews for the Pull Request from",
+    )
 
     # Define optional boolean flags
     parser.add_argument(
@@ -100,6 +107,7 @@ def main():
         base_branch=args.base_branch,
         target_branch=args.target_branch,
         labels=args.labels,
+        reviewers=args.reviewers,
         token=args.token,
         dry_run=args.dry_run,
     )

--- a/helm_bot/github.py
+++ b/helm_bot/github.py
@@ -92,6 +92,27 @@ def add_labels(labels: list, pr_url: str, token: str) -> None:
     )
 
 
+def assign_reviewers(reviewers: list, pr_url: str, token: str) -> None:
+    """Assign reviewers to an open Pull Request
+
+    Args:
+        reviewers (list): A list of GitHub users to request a review for the
+            Pull Request from
+        pr_url (str): The /pulls URL endpoint of the open Pull Request
+        token (str): A GitHub API token
+    """
+    logger.info("Assigning reviewers to Pull Request: %s" % pr_url)
+    logger.info("Assigning reviewers: %s" % reviewers)
+
+    url = pr_url + "/requested_reviewers"
+
+    post_request(
+        url,
+        headers={"Authorization": f"token {token}"},
+        json={"reviewers": reviewers},
+    )
+
+
 def check_fork_exists(repo_name: str, token: str) -> bool:
     """Check if HelmUpgradeBot has a fork of a GitHub repository
 

--- a/helm_bot/github.py
+++ b/helm_bot/github.py
@@ -254,6 +254,7 @@ def create_pr(
     base_branch: str,
     target_branch: str,
     token: str,
+    labels: list = [],
     reviewers: list = [],
 ) -> None:
     """Create a Pull Request to the original repository
@@ -263,6 +264,8 @@ def create_pr(
         base_branch (str): The name of the base branch for the PR
         target_branch (str): The name of the target branch for the PR
         token (str): A GitHub API token
+        labels (list, optional): A list of labels to add to the PR.
+            Defaults to an empty list.
         reviewers (list, optional): A list of GitHub users to request a review
             for the open Pull Request from. Defaults to an empty list.
     """
@@ -284,7 +287,7 @@ def create_pr(
 
     logger.info("Pull Request created")
 
-    if labels is not None:
+    if len(labels) > 0:
         add_labels(labels, resp["issue_url"], token)
 
     if len(reviewers) > 0:

--- a/helm_bot/github.py
+++ b/helm_bot/github.py
@@ -254,7 +254,7 @@ def create_pr(
     base_branch: str,
     target_branch: str,
     token: str,
-    labels: str = None,
+    reviewers: list = [],
 ) -> None:
     """Create a Pull Request to the original repository
 
@@ -263,8 +263,8 @@ def create_pr(
         base_branch (str): The name of the base branch for the PR
         target_branch (str): The name of the target branch for the PR
         token (str): A GitHub API token
-        labels (str, optional): A list of labels to add to the PR.
-                                Defaults to None.
+        reviewers (list, optional): A list of GitHub users to request a review
+            for the open Pull Request from. Defaults to an empty list.
     """
     logger.info("Creating Pull Request")
 
@@ -286,6 +286,9 @@ def create_pr(
 
     if labels is not None:
         add_labels(labels, resp["issue_url"], token)
+
+    if len(reviewers) > 0:
+        assign_reviewers(reviewers, resp["url"], token)
 
 
 def find_existing_pr(repo_api: str, token: str):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,4 @@
-import pytest
 import logging
-from unittest.mock import patch
 from testfixtures import log_capture
 from helm_bot.app import check_versions
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,6 +51,7 @@ def test_parser_boolean_opts(mock_args):
         target_branch="test_target",
         base_branch="test_base",
         labels=["label1", "label2"],
+        reviewers=["reviewer1", "reviewer2"],
     ),
 )
 def test_parser_opts(mock_args):
@@ -66,6 +67,9 @@ def test_parser_opts(mock_args):
             "-l",
             "label1",
             "label2",
+            "-r",
+            "reviewer1",
+            "reviewer2",
         ]
     )
 
@@ -75,6 +79,7 @@ def test_parser_opts(mock_args):
     assert parser.target_branch == "test_target"
     assert parser.base_branch == "test_base"
     assert parser.labels == ["label1", "label2"]
+    assert parser.reviewers == ["reviewer1", "reviewer2"]
     assert mock_args.call_count == 1
 
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -497,7 +497,9 @@ def test_create_pr_no_labels_no_reviewers(capture):
     logger.info("Pull Request created")
 
     with patch("helm_bot.github.post_request", return_value={}) as mock_post:
-        create_pr(repo_api, base_branch, target_branch, token, labels, reviewers)
+        create_pr(
+            repo_api, base_branch, target_branch, token, labels, reviewers
+        )
 
         assert mock_post.call_count == 1
         assert mock_post.return_value == {}
@@ -580,10 +582,14 @@ def test_create_pr_with_reviewers_no_labels(capture):
         "helm_bot.github.post_request",
         return_value={"url": "http://jsonplaceholder.typicode.com/pulls/1"},
     )
-    mock_reviewers = patch("helm_bot.github.assign_reviewers", return_value=None)
+    mock_reviewers = patch(
+        "helm_bot.github.assign_reviewers", return_value=None
+    )
 
     with mock_post as mock1, mock_reviewers as mock2:
-        create_pr(repo_api, base_branch, target_branch, token, reviewers=reviewers)
+        create_pr(
+            repo_api, base_branch, target_branch, token, reviewers=reviewers
+        )
 
         assert mock1.call_count == 1
         assert mock1.return_value == {
@@ -631,10 +637,14 @@ def test_create_pr_with_labels_and_reviewers(capture):
         },
     )
     mock_labels = patch("helm_bot.github.add_labels", return_value=None)
-    mock_reviewers = patch("helm_bot.github.assign_reviewers", return_value=None)
+    mock_reviewers = patch(
+        "helm_bot.github.assign_reviewers", return_value=None
+    )
 
     with mock_post as mock1, mock_labels as mock2, mock_reviewers as mock3:
-        create_pr(repo_api, base_branch, target_branch, token, labels, reviewers)
+        create_pr(
+            repo_api, base_branch, target_branch, token, labels, reviewers
+        )
 
         assert mock1.call_count == 1
         assert mock1.return_value == {

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -6,6 +6,7 @@ from testfixtures import log_capture
 from helm_bot.github import (
     add_commit_push,
     add_labels,
+    assign_reviewers,
     check_fork_exists,
     delete_old_branch,
     checkout_branch,
@@ -119,6 +120,29 @@ def test_add_labels(capture):
             pr_url,
             headers={"Authorization": f"token {token}"},
             json={"labels": labels},
+        )
+
+        capture.check_present()
+
+
+@log_capture()
+def test_assign_reviewers(capture):
+    reviewers = ["reviewer1", "reviewer2"]
+    url = "http://jsonplaceholder.typicode.com/pulls/1"
+    token = "this_is_a_token"
+
+    logger = logging.getLogger()
+    logger.info("Add reviewers to Pull Request: %s" % url)
+    logger.info("Adding reviewers: %s" % reviewers)
+
+    with patch("helm_bot.github.post_request") as mocked_func:
+        assign_reviewers(reviewers, url, token)
+
+        assert mocked_func.call_count == 1
+        mocked_func.assert_called_with(
+            url + "/requested_reviewers",
+            headers={"Authorization": f"token {token}"},
+            json={"reviewers": reviewers},
         )
 
         capture.check_present()
@@ -453,12 +477,13 @@ def test_clone_fork_exception(capture):
 
 
 @log_capture()
-def test_create_pr_no_labels(capture):
+def test_create_pr_no_labels_no_reviewers(capture):
     repo_api = "http://jsonplaceholder.typicode.com/"
     base_branch = "base"
     target_branch = "target"
     token = "this_is_a_token"
-    labels = None
+    labels = []
+    reviewers = []
 
     expected_pr = {
         "title": "Logging Helm Chart version upgrade",
@@ -472,7 +497,7 @@ def test_create_pr_no_labels(capture):
     logger.info("Pull Request created")
 
     with patch("helm_bot.github.post_request", return_value={}) as mock_post:
-        create_pr(repo_api, base_branch, target_branch, token, labels)
+        create_pr(repo_api, base_branch, target_branch, token, labels, reviewers)
 
         assert mock_post.call_count == 1
         assert mock_post.return_value == {}
@@ -487,7 +512,7 @@ def test_create_pr_no_labels(capture):
 
 
 @log_capture()
-def test_create_pr_with_labels(capture):
+def test_create_pr_with_labels_no_reviewers(capture):
     repo_api = "http://jsonplaceholder.typicode.com/"
     base_branch = "base"
     target_branch = "target"
@@ -527,6 +552,108 @@ def test_create_pr_with_labels(capture):
         assert mock2.call_count == 1
         mock2.assert_called_with(
             labels, "http://jsonplaceholder.typicode.com/pr/1", token
+        )
+
+        capture.check_present()
+
+
+@log_capture()
+def test_create_pr_with_reviewers_no_labels(capture):
+    repo_api = "http://jsonplaceholder.typicode.com/"
+    base_branch = "base"
+    target_branch = "target"
+    token = "this_is_a_token"
+    reviewers = ["reviewer1", "reviewer2"]
+
+    expected_pr = {
+        "title": "Logging Helm Chart version upgrade",
+        "body": "This PR is updating the local Helm Chart to the most recent Chart dependency versions.",
+        "base": base_branch,
+        "head": f"HelmUpgradeBot:{target_branch}",
+    }
+
+    logger = logging.getLogger()
+    logger.info("Creating Pull Request")
+    logger.info("Pull Request created")
+
+    mock_post = patch(
+        "helm_bot.github.post_request",
+        return_value={"url": "http://jsonplaceholder.typicode.com/pulls/1"},
+    )
+    mock_reviewers = patch("helm_bot.github.assign_reviewers", return_value=None)
+
+    with mock_post as mock1, mock_reviewers as mock2:
+        create_pr(repo_api, base_branch, target_branch, token, reviewers=reviewers)
+
+        assert mock1.call_count == 1
+        assert mock1.return_value == {
+            "url": "http://jsonplaceholder.typicode.com/pulls/1"
+        }
+        mock1.assert_called_with(
+            repo_api + "pulls",
+            headers={"Authorization": f"token {token}"},
+            json=expected_pr,
+            return_json=True,
+        )
+        assert mock2.call_count == 1
+        mock2.assert_called_with(
+            reviewers, "http://jsonplaceholder.typicode.com/pulls/1", token
+        )
+
+        capture.check_present()
+
+
+@log_capture()
+def test_create_pr_with_labels_and_reviewers(capture):
+    repo_api = "http://jsonplaceholder.typicode.com/"
+    base_branch = "base"
+    target_branch = "target"
+    token = "this_is_a_token"
+    labels = ["label1", "label2"]
+    reviewers = ["reviewer1", "reviewer2"]
+
+    expected_pr = {
+        "title": "Logging Helm Chart version upgrade",
+        "body": "This PR is updating the local Helm Chart to the most recent Chart dependency versions.",
+        "base": base_branch,
+        "head": f"HelmUpgradeBot:{target_branch}",
+    }
+
+    logger = logging.getLogger()
+    logger.info("Creating Pull Request")
+    logger.info("Pull Request created")
+
+    mock_post = patch(
+        "helm_bot.github.post_request",
+        return_value={
+            "issue_url": "http://jsonplaceholder.typicode.com/pr/1",
+            "url": "http://jsonplaceholder.typicode.com/pulls/1",
+        },
+    )
+    mock_labels = patch("helm_bot.github.add_labels", return_value=None)
+    mock_reviewers = patch("helm_bot.github.assign_reviewers", return_value=None)
+
+    with mock_post as mock1, mock_labels as mock2, mock_reviewers as mock3:
+        create_pr(repo_api, base_branch, target_branch, token, labels, reviewers)
+
+        assert mock1.call_count == 1
+        assert mock1.return_value == {
+            "issue_url": "http://jsonplaceholder.typicode.com/pr/1",
+            "url": "http://jsonplaceholder.typicode.com/pulls/1",
+        }
+        mock1.assert_called_with(
+            repo_api + "pulls",
+            headers={"Authorization": f"token {token}"},
+            json=expected_pr,
+            return_json=True,
+        )
+        assert mock2.call_count == 1
+        mock2.assert_called_with(
+            labels, "http://jsonplaceholder.typicode.com/pr/1", token
+        )
+        assert mock3.call_count == 1
+        mock3.assert_called_with(
+            reviewers, "http://jsonplaceholder.typicode.com/pulls/1", token
         )
 
         capture.check_present()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,8 +1,5 @@
 import pytest
-import logging
 import responses
-from unittest.mock import patch
-from testfixtures import log_capture
 from helm_bot.helper_functions import (
     delete_request,
     get_request,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request!

Don't worry, these HTML comments won't render in your issue.
Feel free to delete them once you've read them :) -->

### Summary
<!-- Please describe the purpose of this PR.
Is it fixing a bug or adding a feature?

Please reference relevant issue numbers with action words to close them if relevant. -->

fix #61

This PR adds new functionality to assign reviewers to the Pull Request that the bot opens.

### What's changed?
<!-- You can use this section to go into more detail about what's changed.
We recommend using bullet points. -->

- New `assign_reviewers` function in `github.py` propagated to `create_pr` func
- `reviewers` arg exposed on CLI
- `reviewers` arg parsed through `app.py`
- New tests added for the new functionality
- Bit of cleaning up in the `tests/` directory also

### What should a reviewer concentrate their feedback on?
<!-- You can use this section to request specific feedback.
We recommend using check boxes. -->

- [ ] Everything looks ok?
