### PR TITLE
Add pr_exists arg to get_chart_versions, modify URL

### DIFF
--- a/helm_bot/app.py
+++ b/helm_bot/app.py
@@ -95,6 +95,7 @@ def get_chart_versions(
     repo_name: str,
     branch_name: str,
     token: str,
+    pr_exists: bool = False,
 ) -> dict:
     """Get the versions of dependent charts
 
@@ -105,11 +106,17 @@ def get_chart_versions(
         branch_name (str): The branch of `repo_name` to pull current chart
             versions from
         token (str): A GitHub API token
+        pr_exists (bool): True if HelmUpgradeBot has previously opened a Pull
+            Request. Default: False.
 
     Returns:
         dict: A dictionary containing the chart dependencies and their
               up-to-date versions
     """
+    if pr_exists:
+        repo_owner = "HelmUpgradeBot"
+        branch_name = "blob/" + branch_name
+
     chart_info = {}
     chart_info[chart_name] = {}
     chart_urls = {
@@ -252,7 +259,7 @@ def run(
         branch_name = "main"
 
     chart_info = get_chart_versions(
-        chart_name, repo_owner, repo_name, branch_name, token
+        chart_name, repo_owner, repo_name, branch_name, token, pr_exists
     )
     charts_to_update = check_versions(chart_name, chart_info, dry_run=dry_run)
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request!

Don't worry, these HTML comments won't render in your issue.
Feel free to delete them once you've read them :) -->

### Summary
<!-- Please describe the purpose of this PR.
Is it fixing a bug or adding a feature?

Please reference relevant issue numbers with action words to close them if relevant. -->

Fixes a bug in the bot that, when a PR is open, we edit the URL of the host chart to be from the fork with the branch name prepended with `blob`. This prevents returning a 404.
